### PR TITLE
Values for SUSE's postgresql image

### DIFF
--- a/harbor-helm/templates/database/database-ss.yaml
+++ b/harbor-helm/templates/database/database-ss.yaml
@@ -37,7 +37,8 @@ spec:
         image: {{ .Values.database.internal.initContainerImage.repository }}:{{ .Values.database.internal.initContainerImage.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command: ["/bin/sh"]
-        args: ["-c", "chown -R 999:999 /var/lib/postgresql/data"]
+        # 26:26 are postgres UID/GID numbers in SUSE systems
+        args: ["-c", "chown -R 26:26 /var/lib/postgresql/data"]
         volumeMounts:
         - name: database-data
           mountPath: /var/lib/postgresql/data

--- a/harbor-helm/values.yaml
+++ b/harbor-helm/values.yaml
@@ -648,11 +648,11 @@ database:
     # set the service account to be used, default if left empty
     serviceAccountName: ""
     image:
-      repository: goharbor/harbor-db
-      tag: dev
+      repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-db
+      tag: 12.2
     # the image used by the init container
     initContainerImage:
-      repository: busybox
+      repository: registry.suse.com/suse/sle15
       tag: latest
     # The initial superuser password for internal database
     password: "changeit"


### PR DESCRIPTION
Point to the internal image for now.
Use UID/GID of postgres:postgres present in SLES.