### PR TITLE
Remove hardcoded GIDs from deployments 

### DIFF
--- a/harbor-helm/templates/core/core-dpl.yaml
+++ b/harbor-helm/templates/core/core-dpl.yaml
@@ -29,8 +29,6 @@ spec:
 {{ toYaml .Values.core.podAnnotations | indent 8 }}
 {{- end }}
     spec:
-      securityContext:
-        fsGroup: 10000
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/harbor-helm/templates/jobservice/jobservice-dpl.yaml
+++ b/harbor-helm/templates/jobservice/jobservice-dpl.yaml
@@ -35,8 +35,6 @@ spec:
 {{ toYaml .Values.jobservice.podAnnotations | indent 8 }}
 {{- end }}
     spec:
-      securityContext:
-        fsGroup: 10000
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/harbor-helm/templates/registry/registry-dpl.yaml
+++ b/harbor-helm/templates/registry/registry-dpl.yaml
@@ -35,8 +35,6 @@ spec:
 {{ toYaml .Values.registry.podAnnotations | indent 8 }}
 {{- end }}
     spec:
-      securityContext:
-        fsGroup: 10000
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/harbor-helm/values.yaml
+++ b/harbor-helm/values.yaml
@@ -250,7 +250,7 @@ persistence:
     # and chartmuseum
     type: filesystem
     filesystem:
-      rootdirectory: /storage
+      rootdirectory: /var/lib/docker-registry
       #maxthreads: 100
     azure:
       accountname: accountname


### PR DESCRIPTION
Makes some changes that are aligned with the overall strategy of
setting user permissions in the SUSE registry images [1]:
- remove the podSecurityContext entries and use dynamically generated
UIDs instead. The file/folder ownership for mounted volumes that the
containerized process needs write access to is changed by the entrypoint
- use a default docker-registry data volume mount path that corresponds to the
RPM

[1] https://confluence.suse.com/display/ENGCTNRSTORY/Building+Container+Images+and+Helm+Charts#BuildingContainerImagesandHelmCharts-Fileownership