### PR TITLE
Disable components not supported in initial release (CAPS-48)

### DIFF
--- a/harbor-helm/values.yaml
+++ b/harbor-helm/values.yaml
@@ -531,7 +531,7 @@ clair:
 
 trivy:
   # enabled the flag to enable Trivy scanner
-  enabled: true
+  enabled: false
   image:
     # repository the repository for Trivy adapter image
     repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-trivy-adapter
@@ -582,7 +582,7 @@ trivy:
   podAnnotations: {}
 
 notary:
-  enabled: true
+  enabled: false
   server:
     image:
       repository: goharbor/notary-server-photon


### PR DESCRIPTION
- trivy and notary are marked as optional in TechPreview