### PR TITLE
Bump harbor-db from 12.2 to 12.3

### DIFF
--- a/harbor-helm/values.yaml
+++ b/harbor-helm/values.yaml
@@ -621,7 +621,7 @@ database:
   internal:
     image:
       repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-db
-      tag: 12.2
+      tag: 12.3
     # the image used by the init container
     initContainerImage:
       repository: registry.suse.com/suse/sle15


### PR DESCRIPTION
12.2 is gone, 12.3 should be used by default