### PR TITLE
Update the installation message to not point to upstream repo

### DIFF
--- a/harbor-helm/templates/NOTES.txt
+++ b/harbor-helm/templates/NOTES.txt
@@ -1,3 +1,2 @@
 Please wait for several minutes for Harbor deployment to complete.
 Then you should be able to visit the Harbor portal at {{ .Values.externalURL }}
-For more details, please visit https://github.com/goharbor/harbor


### PR DESCRIPTION
Well the question is, what should it point to? Our development repo (like in the commit) or rather public one on kubernetes-charts? Or some documentation page?