### PR TITLE
Update image tags to match image versioning scheme for Harbor 2.0.0

### DIFF
--- a/harbor-helm/values.yaml
+++ b/harbor-helm/values.yaml
@@ -351,7 +351,7 @@ proxy:
 nginx:
   image:
     repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-nginx
-    tag: 1.16.1
+    tag: 2.0.0-rev1
   replicas: 1
   # resources:
   #  requests:
@@ -366,7 +366,7 @@ nginx:
 portal:
   image:
     repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-portal
-    tag: 2.0.0
+    tag: 2.0.0-rev1
   replicas: 1
 # resources:
 #  requests:
@@ -381,7 +381,7 @@ portal:
 core:
   image:
     repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-core
-    tag: 2.0.0
+    tag: 2.0.0-rev1
   replicas: 1
   ## Liveness probe values
   livenessProbe:
@@ -412,7 +412,7 @@ core:
 jobservice:
   image:
     repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-jobservice
-    tag: 2.0.0
+    tag: 2.0.0-rev1
   replicas: 1
   maxJobWorkers: 10
   # The logger for jobs: "file", "database" or "stdout"
@@ -435,7 +435,7 @@ registry:
   registry:
     image:
       repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-registry
-      tag: 2.7.1
+      tag: 2.0.0-rev1
 
     # resources:
     #  requests:
@@ -444,7 +444,7 @@ registry:
   controller:
     image:
       repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-registryctl
-      tag: 2.0.0
+      tag: 2.0.0-rev1
 
     # resources:
     #  requests:
@@ -536,7 +536,7 @@ trivy:
     # repository the repository for Trivy adapter image
     repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-trivy-adapter
     # tag the tag for Trivy adapter image
-    tag: 0.9.0
+    tag: 2.0.0-rev1
   # replicas the number of Pod replicas
   replicas: 1
   # debugMode the flag to enable Trivy debug mode with more verbose scanning log
@@ -621,11 +621,11 @@ database:
   internal:
     image:
       repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-db
-      tag: 12.3
+      tag: 2.0.0-rev1
     # the image used by the init container
     initContainerImage:
       repository: registry.suse.com/suse/sle15
-      tag: latest
+      tag: 15.2
     # The initial superuser password for internal database
     password: "changeit"
     # resources:
@@ -669,7 +669,7 @@ redis:
   internal:
     image:
       repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-redis
-      tag: 6.0.5
+      tag: 2.0.0-rev1
     # resources:
     #  requests:
     #    memory: 256Mi


### PR DESCRIPTION
The new image versioning scheme is meant to support keeping the image
tags unchanged through the entire CI/CD pipeline:
* use tags derived from the Harbor version value for all images
* include the revision number in the tags, to allow us to release
patches independently of upstream

This commit updates the Harbor helm chart with tag values reflecting
the new scheme.