### PR TITLE
Remove trivy helm chart changes from the 2.0 baseline

### DIFF
--- a/harbor-helm/templates/trivy/trivy-sts.yaml
+++ b/harbor-helm/templates/trivy/trivy-sts.yaml
@@ -30,6 +30,10 @@ spec:
 {{ toYaml .Values.trivy.podAnnotations | indent 8 }}
 {{- end }}
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10000
+        fsGroup: 10000
       automountServiceAccountToken: false
       containers:
         - name: trivy

--- a/harbor-helm/values.yaml
+++ b/harbor-helm/values.yaml
@@ -534,9 +534,9 @@ trivy:
   enabled: false
   image:
     # repository the repository for Trivy adapter image
-    repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-trivy-adapter
+    repository: goharbor/trivy-adapter-photon
     # tag the tag for Trivy adapter image
-    tag: 2.0.0-rev1
+    tag: v2.0.0
   # replicas the number of Pod replicas
   replicas: 1
   # debugMode the flag to enable Trivy debug mode with more verbose scanning log


### PR DESCRIPTION
The 1.4.0 helm chart version in the release-2.0 branch could be used
as a baseline for deploying the 2.0.0 SUSE Registry Tech Preview
version using the images in Devel:CAPS:Registry. However, some
trivy related changes crept through and need to be removed (trivy
is not available in the Tech Preview release).