### PR TITLE
Helm chart update for Private Registry 2.0.1 (CAPS-73)

### DIFF
--- a/harbor-helm/Chart.yaml
+++ b/harbor-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: harbor
-version: 1.4.0
-appVersion: 2.0.0
+version: 1.4.1
+appVersion: 2.0.1
 description: An open source trusted cloud native registry that stores, signs, and scans content
 keywords:
 - docker

--- a/harbor-helm/README.md
+++ b/harbor-helm/README.md
@@ -2,6 +2,6 @@
 
 This is SUSE version of Helm chart for Harbor registry.
 
-It is amost entirely based on 1.4.0 tag of the upstream chart located at [goharbor/harbor-helm](https://github.com/goharbor/harbor-helm/tree/v1.4.0).
+It is amost entirely based on 1.4.1 tag of the upstream chart located at [goharbor/harbor-helm](https://github.com/goharbor/harbor-helm/tree/v1.4.1).
 
-Check [the original README](https://github.com/goharbor/harbor-helm/blob/v1.4.0/README.md).
+Check [the original README](https://github.com/goharbor/harbor-helm/blob/v1.4.1/README.md).

--- a/harbor-helm/templates/_helpers.tpl
+++ b/harbor-helm/templates/_helpers.tpl
@@ -322,7 +322,19 @@ host:port,pool_size,password
 {{- end -}}
 
 {{- define "harbor.noProxy" -}}
-  {{- printf "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s" (include "harbor.core" .) (include "harbor.jobservice" .) (include "harbor.database" .) (include "harbor.chartmuseum" .) (include "harbor.clair" .) (include "harbor.notary-server" .) (include "harbor.notary-signer" .) (include "harbor.registry" .) (include "harbor.portal" .) .Values.proxy.noProxy -}}
+  {{- printf "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s" (include "harbor.core" .) (include "harbor.jobservice" .) (include "harbor.database" .) (include "harbor.chartmuseum" .) (include "harbor.clair" .) (include "harbor.notary-server" .) (include "harbor.notary-signer" .) (include "harbor.registry" .) (include "harbor.portal" .) (include "harbor.trivy" .) .Values.proxy.noProxy -}}
+{{- end -}}
+
+{{- define "harbor.caBundleVolume" -}}
+- name: ca-bundle-certs
+  secret:
+    secretName: {{ .Values.caBundleSecretName }}
+{{- end -}}
+
+{{- define "harbor.caBundleVolumeMount" -}}
+- name: ca-bundle-certs
+  mountPath: /harbor_cust_cert/custom-ca.crt
+  subPath: ca.crt
 {{- end -}}
 
 {{/* scheme for all components except notary because it only support http mode */}}

--- a/harbor-helm/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/harbor-helm/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -37,6 +37,9 @@ spec:
     spec:
       securityContext:
         fsGroup: 10000
+{{- if .Values.chartmuseum.serviceAccountName }}
+      serviceAccountName: {{ .Values.chartmuseum.serviceAccountName }}
+{{- end -}}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -119,6 +122,9 @@ spec:
           mountPath: /harbor_cust_cert/custom-ca-bundle.crt
           subPath: ca.crt
         {{- end }}
+        {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolumeMount" . | indent 8 }}
+        {{- end }}
       volumes:
       - name: chartmuseum-data
       {{- if and .Values.persistence.enabled (eq .Values.persistence.imageChartStorage.type "filesystem") }}
@@ -144,6 +150,9 @@ spec:
       - name: storage-service-ca
         secret:
           secretName: {{ .Values.persistence.imageChartStorage.caBundleSecretName }}
+      {{- end }}
+      {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolume" . | indent 6 }}
       {{- end }}
       {{- with .Values.chartmuseum.nodeSelector }}
       nodeSelector:

--- a/harbor-helm/templates/clair/clair-dpl.yaml
+++ b/harbor-helm/templates/clair/clair-dpl.yaml
@@ -30,6 +30,9 @@ spec:
     spec:
       securityContext:
         fsGroup: 10000
+{{- if .Values.clair.serviceAccountName }}
+      serviceAccountName: {{ .Values.clair.serviceAccountName }}
+{{- end -}}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -70,7 +73,7 @@ spec:
         - name: config
           mountPath: /etc/clair/config.yaml
           subPath: config.yaml
-      {{- if .Values.internalTLS.enabled }}
+        {{- if .Values.internalTLS.enabled }}
         - name: clair-internal-certs
           mountPath: /harbor_cust_cert/harbor_internal_ca.crt
           subPath: ca.crt
@@ -80,6 +83,9 @@ spec:
         - name: clair-internal-certs
           mountPath: /etc/harbor/ssl/clair_adapter.key
           subPath: tls.key
+        {{- end }}
+        {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolumeMount" . | indent 8 }}
         {{- end }}
       - name: adapter
         image: {{ .Values.clair.adapter.image.repository }}:{{ .Values.clair.adapter.image.tag }}
@@ -130,8 +136,9 @@ spec:
 {{- end }}
         ports:
         - containerPort: {{ template "harbor.clairAdapter.containerPort" . }}
-        {{- if .Values.internalTLS.enabled }}
+        {{- if or .Values.internalTLS.enabled .Values.caBundleSecretName }}
         volumeMounts:
+        {{- if .Values.internalTLS.enabled }}
         - name: clair-internal-certs
           mountPath: /harbor_cust_cert/harbor_internal_ca.crt
           subPath: ca.crt
@@ -142,6 +149,10 @@ spec:
           mountPath: /etc/harbor/ssl/clair_adapter.key
           subPath: tls.key
         {{- end }}
+        {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolumeMount" . | indent 8 }}
+        {{- end }}
+        {{- end }}
       volumes:
       - name: config
         secret:
@@ -150,6 +161,9 @@ spec:
       - name: clair-internal-certs
         secret:
           secretName: {{ template "harbor.internalTLS.clair.secretName" . }}
+      {{- end }}
+      {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolume" . | indent 6 }}
       {{- end }}
     {{- with .Values.clair.nodeSelector }}
       nodeSelector:

--- a/harbor-helm/templates/core/core-cm.yaml
+++ b/harbor-helm/templates/core/core-cm.yaml
@@ -51,7 +51,6 @@ data:
   PORTAL_URL: "{{ template "harbor.portalURL" . }}"
   REGISTRY_CONTROLLER_URL: "{{ template "harbor.registryControllerURL" . }}"
   REGISTRY_CREDENTIAL_USERNAME: "{{ .Values.registry.credentials.username }}"
-  CSRF_KEY: "{{ randAlphaNum 32 }}"
   {{- if .Values.uaaSecretName }}
   UAA_CA_ROOT: "/etc/core/auth-ca/auth-ca.crt"
   {{- end }}

--- a/harbor-helm/templates/core/core-dpl.yaml
+++ b/harbor-helm/templates/core/core-dpl.yaml
@@ -29,6 +29,9 @@ spec:
 {{ toYaml .Values.core.podAnnotations | indent 8 }}
 {{- end }}
     spec:
+{{- if .Values.core.serviceAccountName }}
+      serviceAccountName: {{ .Values.core.serviceAccountName }}
+{{- end -}}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -111,6 +114,9 @@ spec:
         {{- end }}
         - name: psc
           mountPath: /etc/core/token
+        {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolumeMount" . | indent 8 }}
+        {{- end }}
 {{- if .Values.core.resources }}
         resources:
 {{ toYaml .Values.core.resources | indent 10 }}
@@ -161,6 +167,9 @@ spec:
       {{- end }}
       - name: psc
         emptyDir: {}
+      {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolume" . | indent 6 }}
+      {{- end }}
     {{- with .Values.core.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/harbor-helm/templates/core/core-secret.yaml
+++ b/harbor-helm/templates/core/core-secret.yaml
@@ -18,3 +18,4 @@ data:
 {{- if .Values.clair.enabled }}
   CLAIR_DB_PASSWORD: {{ template "harbor.database.encryptedPassword" . }}
 {{- end }}
+  CSRF_KEY: {{ .Values.core.xsrfKey | default (randAlphaNum 32) | b64enc | quote }}

--- a/harbor-helm/templates/database/database-ss.yaml
+++ b/harbor-helm/templates/database/database-ss.yaml
@@ -25,6 +25,9 @@ spec:
 {{ toYaml .Values.database.podAnnotations | indent 8 }}
 {{- end }}
     spec:
+{{- if .Values.database.internal.serviceAccountName }}
+      serviceAccountName: {{ .Values.database.internal.serviceAccountName }}
+{{- end -}}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/harbor-helm/templates/internal/auto-tls.yaml
+++ b/harbor-helm/templates/internal/auto-tls.yaml
@@ -73,7 +73,7 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
 type: kubernetes.io/tls
 data:
-  tls.ca: {{ $ca.Cert | b64enc | quote }}
+  ca.crt: {{ $ca.Cert | b64enc | quote }}
   tls.crt: {{ $chartCrt.Cert | b64enc | quote }}
   tls.key: {{ $chartCrt.Key | b64enc | quote }}
 {{- end }}

--- a/harbor-helm/templates/jobservice/jobservice-dpl.yaml
+++ b/harbor-helm/templates/jobservice/jobservice-dpl.yaml
@@ -35,6 +35,9 @@ spec:
 {{ toYaml .Values.jobservice.podAnnotations | indent 8 }}
 {{- end }}
     spec:
+{{- if .Values.jobservice.serviceAccountName }}
+      serviceAccountName: {{ .Values.jobservice.serviceAccountName }}
+{{- end -}}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -102,6 +105,9 @@ spec:
           mountPath: /etc/harbor/ssl/job_service.key
           subPath: tls.key
         {{- end }}
+        {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolumeMount" . | indent 8 }}
+        {{- end }}
       volumes:
       - name: jobservice-config
         configMap:
@@ -117,6 +123,9 @@ spec:
       - name: jobservice-internal-certs
         secret:
           secretName: {{ template "harbor.internalTLS.jobservice.secretName" . }}
+      {{- end }}
+      {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolume" . | indent 6 }}
       {{- end }}
     {{- with .Values.jobservice.nodeSelector }}
       nodeSelector:

--- a/harbor-helm/templates/nginx/deployment.yaml
+++ b/harbor-helm/templates/nginx/deployment.yaml
@@ -30,6 +30,9 @@ spec:
 {{ toYaml .Values.nginx.podAnnotations | indent 8 }}
 {{- end }}
     spec:
+{{- if .Values.nginx.serviceAccountName }}
+      serviceAccountName: {{ .Values.nginx.serviceAccountName }}
+{{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/harbor-helm/templates/notary/notary-server.yaml
+++ b/harbor-helm/templates/notary/notary-server.yaml
@@ -26,6 +26,9 @@ spec:
     spec:
       securityContext:
         fsGroup: 10000
+{{- if .Values.notary.server.serviceAccountName }}
+      serviceAccountName: {{ .Values.notary.server.serviceAccountName }}
+{{- end -}}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/harbor-helm/templates/notary/notary-signer.yaml
+++ b/harbor-helm/templates/notary/notary-signer.yaml
@@ -22,6 +22,9 @@ spec:
     spec:
       securityContext:
         fsGroup: 10000
+{{- if .Values.notary.signer.serviceAccountName }}
+      serviceAccountName: {{ .Values.notary.signer.serviceAccountName }}
+{{- end -}}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/harbor-helm/templates/portal/deployment.yaml
+++ b/harbor-helm/templates/portal/deployment.yaml
@@ -30,6 +30,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- if .Values.portal.serviceAccountName }}
+      serviceAccountName: {{ .Values.portal.serviceAccountName }}
+{{- end }}
       containers:
       - name: portal
         image: {{ .Values.portal.image.repository }}:{{ .Values.portal.image.tag }}

--- a/harbor-helm/templates/redis/statefulset.yaml
+++ b/harbor-helm/templates/redis/statefulset.yaml
@@ -24,6 +24,9 @@ spec:
 {{ toYaml .Values.redis.podAnnotations | indent 8 }}
 {{- end }}
     spec:
+{{- if .Values.redis.internal.serviceAccountName }}
+      serviceAccountName: {{ .Values.redis.internal.serviceAccountName }}
+{{- end -}}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/harbor-helm/templates/registry/registry-dpl.yaml
+++ b/harbor-helm/templates/registry/registry-dpl.yaml
@@ -35,6 +35,9 @@ spec:
 {{ toYaml .Values.registry.podAnnotations | indent 8 }}
 {{- end }}
     spec:
+{{- if .Values.registry.serviceAccountName }}
+      serviceAccountName: {{ .Values.registry.serviceAccountName }}
+{{- end -}}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -128,6 +131,9 @@ spec:
           subPath: pk.pem
         {{- end }}
         {{- end }}
+        {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolumeMount" . | indent 8 }}
+        {{- end }}
       - name: registryctl
         image: {{ .Values.registry.controller.image.repository }}:{{ .Values.registry.controller.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -207,6 +213,9 @@ spec:
           mountPath: /etc/registry/gcs-key.json
           subPath: gcs-key.json
         {{- end }}
+        {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolumeMount" . | indent 8 }}
+        {{- end }}
       volumes:
       - name: registry-htpasswd
         secret:
@@ -258,6 +267,9 @@ spec:
             - key: CLOUDFRONT_KEY_DATA
               path: pk.pem
       {{- end }}
+      {{- end }}
+      {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolume" . | indent 6 }}
       {{- end }}
     {{- with .Values.registry.nodeSelector }}
       nodeSelector:

--- a/harbor-helm/templates/trivy/trivy-sts.yaml
+++ b/harbor-helm/templates/trivy/trivy-sts.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.trivy.enabled }}
-{{- $trivyPVC := .Values.persistence.persistentVolumeClaim.trivy }}
+{{- $trivy := .Values.persistence.persistentVolumeClaim.trivy }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -30,6 +30,13 @@ spec:
 {{ toYaml .Values.trivy.podAnnotations | indent 8 }}
 {{- end }}
     spec:
+{{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+{{- end }}
+{{- if .Values.trivy.serviceAccountName }}
+      serviceAccountName: {{ .Values.trivy.serviceAccountName }}
+{{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 10000
@@ -43,6 +50,14 @@ spec:
             privileged: false
             allowPrivilegeEscalation: false
           env:
+          {{- if has "trivy" .Values.proxy.components }}
+            - name: HTTP_PROXY
+              value: "{{ .Values.proxy.httpProxy }}"
+            - name: HTTPS_PROXY
+              value: "{{ .Values.proxy.httpsProxy }}"
+            - name: NO_PROXY
+              value: "{{ template "harbor.noProxy" . }}"
+          {{- end }}
             - name: "SCANNER_LOG_LEVEL"
               value: {{ .Values.logLevel | quote }}
             - name: "SCANNER_TRIVY_CACHE_DIR"
@@ -90,11 +105,10 @@ spec:
             - name: api-server
               containerPort: {{ template "harbor.trivy.containerPort" . }}
           volumeMounts:
-            - name: data
-              mountPath: /home/scanner/.cache
-              readOnly: false
+          - name: data
+            mountPath: /home/scanner/.cache
+            readOnly: false
           {{- if .Values.internalTLS.enabled }}
-          volumeMounts:
           - name: trivy-internal-certs
             mountPath: /harbor_cust_cert/harbor_internal_ca.crt
             subPath: ca.crt
@@ -104,6 +118,9 @@ spec:
           - name: trivy-internal-certs
             mountPath: /etc/harbor/ssl/trivy.key
             subPath: tls.key
+          {{- end }}
+          {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolumeMount" . | indent 10 }}
           {{- end }}
           livenessProbe:
             httpGet:
@@ -125,28 +142,42 @@ spec:
             failureThreshold: 3
           resources:
 {{ toYaml .Values.trivy.resources | indent 12 }}
-      {{- if .Values.internalTLS.enabled }}
+      {{- if or (or .Values.internalTLS.enabled .Values.caBundleSecretName) (or (not .Values.persistence.enabled) $trivy.existingClaim) }}
       volumes:
-        - name: trivy-internal-certs
-          secret:
-            secretName: {{ template "harbor.internalTLS.trivy.secretName" . }}
+      {{- if .Values.internalTLS.enabled }}
+      - name: trivy-internal-certs
+        secret:
+          secretName: {{ template "harbor.internalTLS.trivy.secretName" . }}
       {{- end }}
+      {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolume" . | indent 6 }}
+      {{- end }}
+      {{- if not .Values.persistence.enabled }}
+      - name: "data"
+        emptyDir: {}
+      {{- else if $trivy.existingClaim }}
+      - name: "data"
+        persistentVolumeClaim:
+          claimName: {{ $trivy.existingClaim }}
+      {{- end }}
+      {{- end }}
+{{- if and .Values.persistence.enabled (not $trivy.existingClaim) }}
   volumeClaimTemplates:
-    - metadata:
-        name: data
-        labels:
-{{ include "harbor.labels" . | indent 10 }}
-      spec:
-        accessModes:
-          - {{ $trivyPVC.accessMode | quote }}
-        {{- if $trivyPVC.storageClass }}
-        {{- if (eq "-" $trivyPVC.storageClass) }}
-        storageClassName: ""
-        {{- else }}
-        storageClassName: "{{ $trivyPVC.storageClass }}"
-        {{- end }}
-        {{- end }}
-        resources:
-          requests:
-            storage: {{ $trivyPVC.size | quote }}
+  - metadata:
+      name: data
+      labels:
+{{ include "harbor.labels" . | indent 8 }}
+    spec:
+      accessModes: [{{ $trivy.accessMode | quote }}]
+      {{- if $trivy.storageClass }}
+      {{- if (eq "-" $trivy.storageClass) }}
+      storageClassName: ""
+      {{- else }}
+      storageClassName: "{{ $trivy.storageClass }}"
+      {{- end }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ $trivy.size | quote }}
+{{- end }}
 {{- end }}

--- a/harbor-helm/values.yaml
+++ b/harbor-helm/values.yaml
@@ -355,8 +355,8 @@ proxy:
 # If expose the service via "ingress", the Nginx will not be used
 nginx:
   image:
-    repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-nginx
-    tag: 2.0.0-rev1
+    repository: registry.suse.de/devel/caps/registry/2.0/containers/registry/harbor-nginx
+    tag: 2.0.1-rev1
   # set the service account to be used, default if left empty
   serviceAccountName: ""
   replicas: 1
@@ -372,8 +372,8 @@ nginx:
 
 portal:
   image:
-    repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-portal
-    tag: 2.0.0-rev1
+    repository: registry.suse.de/devel/caps/registry/2.0/containers/registry/harbor-portal
+    tag: 2.0.1-rev1
   # set the service account to be used, default if left empty
   serviceAccountName: ""
   replicas: 1
@@ -389,8 +389,8 @@ portal:
 
 core:
   image:
-    repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-core
-    tag: 2.0.0-rev1
+    repository: registry.suse.de/devel/caps/registry/2.0/containers/registry/harbor-core
+    tag: 2.0.1-rev1
   # set the service account to be used, default if left empty
   serviceAccountName: ""
   replicas: 1
@@ -422,8 +422,8 @@ core:
 
 jobservice:
   image:
-    repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-jobservice
-    tag: 2.0.0-rev1
+    repository: registry.suse.de/devel/caps/registry/2.0/containers/registry/harbor-jobservice
+    tag: 2.0.1-rev1
   replicas: 1
   # set the service account to be used, default if left empty
   serviceAccountName: ""
@@ -449,8 +449,8 @@ registry:
   serviceAccountName: ""
   registry:
     image:
-      repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-registry
-      tag: 2.0.0-rev1
+      repository: registry.suse.de/devel/caps/registry/2.0/containers/registry/harbor-registry
+      tag: 2.0.1-rev1
 
     # resources:
     #  requests:
@@ -458,8 +458,8 @@ registry:
     #    cpu: 100m
   controller:
     image:
-      repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-registryctl
-      tag: 2.0.0-rev1
+      repository: registry.suse.de/devel/caps/registry/2.0/containers/registry/harbor-registryctl
+      tag: 2.0.1-rev1
 
     # resources:
     #  requests:
@@ -649,8 +649,8 @@ database:
     # set the service account to be used, default if left empty
     serviceAccountName: ""
     image:
-      repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-db
-      tag: 2.0.0-rev1
+      repository: registry.suse.de/devel/caps/registry/2.0/containers/registry/harbor-db
+      tag: 2.0.1-rev1
     # the image used by the init container
     initContainerImage:
       repository: registry.suse.com/suse/sle15
@@ -699,8 +699,8 @@ redis:
     # set the service account to be used, default if left empty
     serviceAccountName: ""
     image:
-      repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-redis
-      tag: 2.0.0-rev1
+      repository: registry.suse.de/devel/caps/registry/2.0/containers/registry/harbor-redis
+      tag: 2.0.1-rev1
     # resources:
     #  requests:
     #    memory: 256Mi

--- a/harbor-helm/values.yaml
+++ b/harbor-helm/values.yaml
@@ -339,6 +339,11 @@ proxy:
     - core
     - jobservice
     - clair
+    - trivy
+
+# The custom ca bundle secret, the secret must contain key named "ca.crt"
+# which will be injected into the trust store for chartmuseum, clair, core, jobservice, registry, trivy components
+# caBundleSecretName: ""
 
 ## UAA Authentication Options
 # If you're using UAA for authentication behind a self-signed
@@ -352,6 +357,8 @@ nginx:
   image:
     repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-nginx
     tag: 2.0.0-rev1
+  # set the service account to be used, default if left empty
+  serviceAccountName: ""
   replicas: 1
   # resources:
   #  requests:
@@ -367,6 +374,8 @@ portal:
   image:
     repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-portal
     tag: 2.0.0-rev1
+  # set the service account to be used, default if left empty
+  serviceAccountName: ""
   replicas: 1
 # resources:
 #  requests:
@@ -382,6 +391,8 @@ core:
   image:
     repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-core
     tag: 2.0.0-rev1
+  # set the service account to be used, default if left empty
+  serviceAccountName: ""
   replicas: 1
   ## Liveness probe values
   livenessProbe:
@@ -414,6 +425,8 @@ jobservice:
     repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-jobservice
     tag: 2.0.0-rev1
   replicas: 1
+  # set the service account to be used, default if left empty
+  serviceAccountName: ""
   maxJobWorkers: 10
   # The logger for jobs: "file", "database" or "stdout"
   jobLogger: file
@@ -432,6 +445,8 @@ jobservice:
   secret: ""
 
 registry:
+  # set the service account to be used, default if left empty
+  serviceAccountName: ""
   registry:
     image:
       repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-registry
@@ -450,6 +465,8 @@ registry:
     #  requests:
     #    memory: 256Mi
     #    cpu: 100m
+  # set the service account to be used, default if left empty
+  serviceAccountName: ""
   replicas: 1
   nodeSelector: {}
   tolerations: []
@@ -485,11 +502,13 @@ registry:
 
 chartmuseum:
   enabled: false
+  # set the service account to be used, default if left empty
+  serviceAccountName: ""
   # Harbor defaults ChartMuseum to returning relative urls, if you want using absolute url you should enable it by change the following value to 'true'
   absoluteUrl: false
   image:
     repository: goharbor/chartmuseum-photon
-    tag: v2.0.0
+    tag: v2.0.1
   replicas: 1
   # resources:
   #  requests:
@@ -503,10 +522,12 @@ chartmuseum:
 
 clair:
   enabled: false
+  # set the service account to be used, default if left empty
+  serviceAccountName: ""
   clair:
     image:
       repository: goharbor/clair-photon
-      tag: v2.0.0
+      tag: v2.0.1
     # resources:
     #  requests:
     #    memory: 256Mi
@@ -514,7 +535,7 @@ clair:
   adapter:
     image:
       repository: goharbor/clair-adapter-photon
-      tag: v2.0.0
+      tag: v2.0.1
     # resources:
     #  requests:
     #    memory: 256Mi
@@ -536,7 +557,9 @@ trivy:
     # repository the repository for Trivy adapter image
     repository: goharbor/trivy-adapter-photon
     # tag the tag for Trivy adapter image
-    tag: v2.0.0
+    tag: v2.0.1
+  # set the service account to be used, default if left empty
+  serviceAccountName: ""
   # replicas the number of Pod replicas
   replicas: 1
   # debugMode the flag to enable Trivy debug mode with more verbose scanning log
@@ -584,18 +607,22 @@ trivy:
 notary:
   enabled: false
   server:
+    # set the service account to be used, default if left empty
+    serviceAccountName: ""
     image:
       repository: goharbor/notary-server-photon
-      tag: v2.0.0
+      tag: v2.0.1
     replicas: 1
     # resources:
     #  requests:
     #    memory: 256Mi
     #    cpu: 100m
   signer:
+    # set the service account to be used, default if left empty
+    serviceAccountName: ""
     image:
       repository: goharbor/notary-signer-photon
-      tag: v2.0.0
+      tag: v2.0.1
     replicas: 1
     # resources:
     #  requests:
@@ -619,6 +646,8 @@ database:
   # and fill the connection informations in "external" section
   type: internal
   internal:
+    # set the service account to be used, default if left empty
+    serviceAccountName: ""
     image:
       repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-db
       tag: 2.0.0-rev1
@@ -667,6 +696,8 @@ redis:
   # and fill the connection informations in "external" section
   type: internal
   internal:
+    # set the service account to be used, default if left empty
+    serviceAccountName: ""
     image:
       repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-redis
       tag: 2.0.0-rev1


### PR DESCRIPTION
Syncs helm chart with upstream v1.4.1 (Harbor 2.0.1) and updates
SUSE helm chart image versions to `2.0.1-rev1`.

Applies all commits from upstream that were done between v1.4.0
(our previous baseline) and v1.4.1.
    
Images used for the 2.0.1 Private Registry release are uniquely tagged
with `2.0.1-rev1`. They also come from a different IBS project:
`Devel:CAPS:Registry:2.0`.