### PR TITLE
[2.0] Run change-permission-of-directory container with DB image

### DIFF
--- a/harbor-helm/templates/database/database-ss.yaml
+++ b/harbor-helm/templates/database/database-ss.yaml
@@ -34,11 +34,12 @@ spec:
       {{- end }}
       initContainers:
       - name: "change-permission-of-directory"
-        image: {{ .Values.database.internal.initContainerImage.repository }}:{{ .Values.database.internal.initContainerImage.tag }}
+        securityContext:
+          runAsUser: 0
+        image: {{ .Values.database.internal.image.repository }}:{{ .Values.database.internal.image.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command: ["/bin/sh"]
-        # 26:26 are postgres UID/GID numbers in SUSE systems
-        args: ["-c", "chown -R 26:26 /var/lib/postgresql/data"]
+        args: ["-c", "chown -R postgres:postgres /var/lib/postgresql/data"]
         volumeMounts:
         - name: database-data
           mountPath: /var/lib/postgresql/data

--- a/harbor-helm/values.yaml
+++ b/harbor-helm/values.yaml
@@ -651,10 +651,6 @@ database:
     image:
       repository: registry.suse.de/devel/caps/registry/2.0/containers/registry/harbor-db
       tag: 2.0.1-rev1
-    # the image used by the init container
-    initContainerImage:
-      repository: registry.suse.com/suse/sle15
-      tag: 15.2
     # The initial superuser password for internal database
     password: "changeit"
     # resources:


### PR DESCRIPTION
(backports #20)

If the init container is run with the DB image and explicit runAsUser: 0
security context, it has several advantages:

- no need to need extra image for init container (busybox in this case)
- possibility to run "chown" command with user:group name instead of UID:GID,
which means the whole DB deployment can work with different database images,
without the need to adapt UID:GID values

Upstream Harbor/1.4.0 PR: https://github.com/goharbor/harbor-helm/pull/685