### PR TITLE
[2.0] Add support for running API test with helm

### DIFF
--- a/harbor-helm/templates/_helpers.tpl
+++ b/harbor-helm/templates/_helpers.tpl
@@ -586,3 +586,44 @@ host:port,pool_size,password
     {{- printf "%s-trivy-internal-tls" (include "harbor.fullname" .) -}}
   {{- end -}}
 {{- end -}}
+
+{{- define "harbor.test" -}}
+  {{- printf "%s-test" (include "harbor.fullname" .) -}}
+{{- end -}}
+
+{{- define "harbor.tests.api.abortOnFailure" -}}
+  {{- if .Values.tests.api.abortOnFailure -}}
+    {{- printf "-X" }}
+  {{- end -}}
+{{- end -}}
+
+{{- define "harbor.tests.api.include" -}}
+  {{- if .Values.tests.api.include -}}
+    {{- printf "-i %s" (.Values.tests.api.include | join " -i ") }}
+  {{- end -}}
+{{- end -}}
+
+# Build exclude list accordingly to enabled services
+{{- define "harbor.tests.api.exclude" -}}
+  {{- $el := .Values.tests.api.exclude -}}
+  {{- if not .Values.chartmuseum.enabled -}}
+    {{- $el = append $el "list_helm_charts" -}}
+  {{- end -}}
+  {{- if not .Values.notary.enabled -}}
+    {{- $el = append $el "sign_image" -}}
+  {{- end -}}
+  {{- if not .Values.trivy.enabled -}}
+    {{- $el = append $el "push_index" -}}
+  {{- end -}}
+  {{- if or (not .Values.trivy.enabled) (not .Values.clair.enabled) -}}
+    {{- $el = append $el "scan" -}}
+    {{- $el = append $el "scan_all" -}}
+  {{- end -}}
+  {{- if $el -}}
+    {{- printf "-e %s" ($el | join " -e ") }}
+  {{- end -}}
+{{- end -}}
+
+{{- define "harbor.tests.api.options" -}}
+  {{- printf "%s %s %s" (include "harbor.tests.api.include" .) (include "harbor.tests.api.exclude" .) (include "harbor.tests.api.abortOnFailure" .) }}
+{{- end -}}

--- a/harbor-helm/templates/tests/api.yaml
+++ b/harbor-helm/templates/tests/api.yaml
@@ -1,0 +1,111 @@
+{{- if .Values.tests.api.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ template "harbor.test" . }}-api"
+  labels:
+{{ include "harbor.labels" . | indent 4 }}
+    component: tests-api
+  annotations:
+    {{- if .Values.tests.api.podAnnotations }}
+      {{ toYaml .Values.tests.api.podAnnotations | indent 4 }}
+    {{- end }}
+    helm.sh/hook: test-success
+spec:
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  containers:
+    - name: api-tests
+      image: {{ .Values.tests.api.image.repository }}:{{ .Values.tests.api.image.tag }}
+      imagePullPolicy: {{ .Values.imagePullPolicy }}
+      command: ["/bin/bash", "-c"]
+      args:
+        - |
+          trap "touch /sidecar/main-terminated" EXIT
+          /usr/local/bin/entrypoint.sh
+      env:
+        - name: HARBOR_IP
+          value: {{ .Values.externalURL | replace "https://" "" }}
+        - name: ROBOT_OPTIONS
+          value: "{{ template "harbor.tests.api.options" . }}"
+        - name: DOCKER_HOST
+          value: "tcp://localhost:2376"
+        - name: DOCKER_TLS_VERIFY
+          value: "1"
+        - name: DOCKER_CERT_PATH
+          value: /certs/client
+      volumeMounts:
+        - name: sidecar
+          mountPath: /sidecar
+        - name: dind-certs
+          mountPath: /certs/client
+          readOnly: true
+        - name: containerd-socket
+          mountPath: /run/containerd
+        {{- if .Values.expose.tls.enabled }}
+        - name: ca-download
+          mountPath: /usr/share/pki/trust/anchors
+          readOnly: true
+        {{- end }}
+{{- if .Values.tests.api.resources }}
+      resources:
+{{ toYaml .Values.tests.api.resources | indent 8 }}
+{{- end }}
+    - name: sidecar-docker-server
+      image: {{ .Values.tests.api.dind.image.repository }}:{{ .Values.tests.api.dind.image.tag }}
+      imagePullPolicy: {{ .Values.imagePullPolicy }}
+      command: ["/bin/sh", "-c"]
+      args:
+        - |
+          dockerd-entrypoint.sh --storage-driver=vfs --userland-proxy=false &
+          CHILD_PID=$!
+          (while true; do if [[ -f "/sidecar/main-terminated" ]]; then kill $CHILD_PID; fi; sleep 1; done) &
+          wait $CHILD_PID
+          if [[ -f "/sidecar/main-terminated" ]]; then exit 0; fi
+      env:
+        - name: DOCKER_TLS_CERTDIR
+          value: /certs
+      volumeMounts:
+        - name: sidecar
+          mountPath: /sidecar
+          readOnly: true
+        - name: dind-certs
+          mountPath: /certs/client
+        - name: containerd-socket
+          mountPath: /var/run/docker/containerd
+        {{- if .Values.expose.tls.enabled }}
+        - name: ca-download
+          mountPath: /etc/docker/certs.d/{{ .Values.externalURL | replace "https://" "" }}
+          readOnly: true
+        {{- end }}
+      securityContext:
+        privileged: true
+{{- if .Values.tests.api.dind.resources }}
+      resources:
+{{ toYaml .Values.tests.api.dind.resources | indent 8 }}
+{{- end }}
+  volumes:
+    - name: sidecar
+      emptyDir: {}
+    - name: dind-certs
+      emptyDir: {}
+    - name: containerd-socket
+      emptyDir: {}
+    {{- if .Values.expose.tls.enabled }}
+    - name: ca-download
+      secret:
+      {{- if eq (include "harbor.autoGenCertForIngress" .) "true" }}
+        secretName: "{{ template "harbor.ingress" . }}"
+      {{- else if eq (include "harbor.autoGenCertForNginx" .) "true" }}
+        secretName: {{ template "harbor.nginx" . }}
+      {{- else }}
+        secretName: {{ .Values.expose.tls.secretName }}
+      {{- end }}
+        items:
+          - key: ca.crt
+            path: ca.crt
+    {{- end }}
+  restartPolicy: Never
+{{- end }}

--- a/harbor-helm/values.yaml
+++ b/harbor-helm/values.yaml
@@ -718,3 +718,35 @@ redis:
     password: ""
   ## Additional deployment annotations
   podAnnotations: {}
+
+# Tests that can be executed by using helm test
+tests:
+  api:
+    # Enable/disable API tests
+    enabled: true
+    # Stops test execution if any test fails
+    abortOnFailure: false
+    # Select test cases to run by tag
+    include: []
+    # Select test cases not to run by tag. These tests are not run
+    # even if included on the include list.
+    # Note: Some tests are automatically skipped according to the
+    # harbor enabled services/features.
+    exclude:
+      - singularity # CLI not yet included in the harbor-test-image
+    image:
+      repository: registry.suse.de/devel/caps/registry/2.0/containers/registry/harbor-test
+      tag: 2.0.2-rev1
+    # resources:
+    #  requests:
+    #    memory: 128Mi
+    #    cpu: 100m
+    dind:
+      image:
+        repository: registry.suse.de/devel/caps/registry/2.0/containers/registry/docker-dind
+        tag: 2.0.2-rev1
+      # resources:
+      #  requests:
+      #    memory: 128Mi
+      #    cpu: 100m
+    podAnnotations: {}


### PR DESCRIPTION
This change introduces support for running Harbor API tests by using the
helm test command.

The tests are executed in a pod with 2 containers, one for the test
execution itself and the other one running docker daemon. The tests are
the same API tests executed by the Harbor upstream project.

Note: to allow anyone to test this, change the images used for harbor
tests are referencing home/flaviosr. Before merging the test images
needs to be updated with the correct values in the `values.yaml` file.

(cherry picked from commit db4285b4350a48bef103700c241eb11ff35f59f5)