### PR TITLE
Use official image tags and registry paths by default (CAPS-97)

### DIFF
--- a/harbor-helm/Chart.yaml
+++ b/harbor-helm/Chart.yaml
@@ -1,3 +1,6 @@
+#!BuildTag: registry/harbor:latest
+#!BuildTag: registry/harbor:1.4.0
+#!BuildTag: registry/harbor:1.4.0-build%RELEASE%
 apiVersion: v1
 name: harbor
 version: 1.4.0

--- a/harbor-helm/values-dev.yaml
+++ b/harbor-helm/values-dev.yaml
@@ -1,0 +1,50 @@
+nginx:
+  image:
+    repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-nginx
+
+portal:
+  image:
+    repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-portal
+
+core:
+  image:
+    repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-core
+
+jobservice:
+  image:
+    repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-jobservice
+
+registry:
+  registry:
+    image:
+      repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-registry
+
+trivy:
+  image:
+    repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-trivy-adapter
+
+notary:
+  server:
+    image:
+      repository: goharbor/notary-server-photon
+  signer:
+    image:
+      repository: goharbor/notary-signer-photon
+
+database:
+  internal:
+    image:
+      repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-db
+
+redis:
+  internal:
+    image:
+      repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-redis
+
+tests:
+  api:
+    image:
+      repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-test
+    dind:
+      image:
+        repository: registry.suse.de/devel/caps/registry/containers/registry/docker-dind

--- a/harbor-helm/values.yaml
+++ b/harbor-helm/values.yaml
@@ -350,8 +350,8 @@ proxy:
 # If expose the service via "ingress", the Nginx will not be used
 nginx:
   image:
-    repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-nginx
-    tag: 2.0.0-rev1
+    repository: registry.suse.com/registry/harbor-nginx
+    tag: 2.0.0
   replicas: 1
   # resources:
   #  requests:
@@ -365,8 +365,8 @@ nginx:
 
 portal:
   image:
-    repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-portal
-    tag: 2.0.0-rev1
+    repository: registry.suse.com/registry/harbor-portal
+    tag: 2.0.0
   replicas: 1
 # resources:
 #  requests:
@@ -380,8 +380,8 @@ portal:
 
 core:
   image:
-    repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-core
-    tag: 2.0.0-rev1
+    repository: registry.suse.com/registry/harbor-core
+    tag: 2.0.0
   replicas: 1
   ## Liveness probe values
   livenessProbe:
@@ -411,8 +411,8 @@ core:
 
 jobservice:
   image:
-    repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-jobservice
-    tag: 2.0.0-rev1
+    repository: registry.suse.com/registry/harbor-jobservice
+    tag: 2.0.0
   replicas: 1
   maxJobWorkers: 10
   # The logger for jobs: "file", "database" or "stdout"
@@ -434,8 +434,8 @@ jobservice:
 registry:
   registry:
     image:
-      repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-registry
-      tag: 2.0.0-rev1
+      repository: registry.suse.com/registry/harbor-registry
+      tag: 2.0.0
 
     # resources:
     #  requests:
@@ -443,8 +443,8 @@ registry:
     #    cpu: 100m
   controller:
     image:
-      repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-registryctl
-      tag: 2.0.0-rev1
+      repository: registry.suse.com/registry/harbor-registryctl
+      tag: 2.0.0
 
     # resources:
     #  requests:
@@ -534,9 +534,9 @@ trivy:
   enabled: false
   image:
     # repository the repository for Trivy adapter image
-    repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-trivy-adapter
+    repository: registry.suse.com/registry/harbor-trivy-adapter
     # tag the tag for Trivy adapter image
-    tag: 2.0.0-rev1
+    tag: 2.0.0
   # replicas the number of Pod replicas
   replicas: 1
   # debugMode the flag to enable Trivy debug mode with more verbose scanning log
@@ -620,8 +620,8 @@ database:
   type: internal
   internal:
     image:
-      repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-db
-      tag: 2.0.0-rev1
+      repository: registry.suse.com/registry/harbor-db
+      tag: 2.0.0
     # The initial superuser password for internal database
     password: "changeit"
     # resources:
@@ -664,8 +664,8 @@ redis:
   type: internal
   internal:
     image:
-      repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-redis
-      tag: 2.0.0-rev1
+      repository: registry.suse.com/registry/harbor-redis
+      tag: 2.0.0
     # resources:
     #  requests:
     #    memory: 256Mi
@@ -703,16 +703,16 @@ tests:
     # harbor enabled services/features.
     exclude: []
     image:
-      repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-test
-      tag: 2.0.0-rev1
+      repository: registry.suse.com/registry/harbor-test
+      tag: 2.0.0
     # resources:
     #  requests:
     #    memory: 128Mi
     #    cpu: 100m
     dind:
       image:
-        repository: registry.suse.de/devel/caps/registry/containers/registry/docker-dind
-        tag: 2.0.0-rev1
+        repository: registry.suse.com/registry/docker-dind
+        tag: 2.0.0
       # resources:
       #  requests:
       #    memory: 128Mi


### PR DESCRIPTION
Insert tag macros into the Chart.yaml file, to be filled in at
build time by the build service.

Use registry.suse.com as the default registry for image references
in the helm chart and only reference version tags (i.e. without
any revision or build numbers).

Add a values-dev.yaml override that can be used as an additional
helm values file to point to development images coming from
registry.suse.de. This can also be replaced by a build source
service with a registry path corresponding to the build project
where the chart is actually built.