### PR TITLE
[2.0] Use official image tags and registry paths by default (CAPS-97)

### DIFF
--- a/harbor-helm/Chart.yaml
+++ b/harbor-helm/Chart.yaml
@@ -1,3 +1,6 @@
+#!BuildTag: registry/harbor:latest
+#!BuildTag: registry/harbor:1.4.2
+#!BuildTag: registry/harbor:1.4.2-build%RELEASE%
 apiVersion: v1
 name: harbor
 version: 1.4.2

--- a/harbor-helm/values-dev.yaml
+++ b/harbor-helm/values-dev.yaml
@@ -1,0 +1,50 @@
+nginx:
+  image:
+    repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-nginx
+
+portal:
+  image:
+    repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-portal
+
+core:
+  image:
+    repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-core
+
+jobservice:
+  image:
+    repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-jobservice
+
+registry:
+  registry:
+    image:
+      repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-registry
+
+trivy:
+  image:
+    repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-trivy-adapter
+
+notary:
+  server:
+    image:
+      repository: goharbor/notary-server-photon
+  signer:
+    image:
+      repository: goharbor/notary-signer-photon
+
+database:
+  internal:
+    image:
+      repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-db
+
+redis:
+  internal:
+    image:
+      repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-redis
+
+tests:
+  api:
+    image:
+      repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-test
+    dind:
+      image:
+        repository: registry.suse.de/devel/caps/registry/containers/registry/docker-dind

--- a/harbor-helm/values.yaml
+++ b/harbor-helm/values.yaml
@@ -355,8 +355,8 @@ proxy:
 # If expose the service via "ingress", the Nginx will not be used
 nginx:
   image:
-    repository: registry.suse.de/devel/caps/registry/2.0/containers/registry/harbor-nginx
-    tag: 2.0.2-rev1
+    repository: registry.suse.com/registry/harbor-nginx
+    tag: 2.0.2
   # set the service account to be used, default if left empty
   serviceAccountName: ""
   replicas: 1
@@ -372,8 +372,8 @@ nginx:
 
 portal:
   image:
-    repository: registry.suse.de/devel/caps/registry/2.0/containers/registry/harbor-portal
-    tag: 2.0.2-rev1
+    repository: registry.suse.com/registry/harbor-portal
+    tag: 2.0.2
   # set the service account to be used, default if left empty
   serviceAccountName: ""
   replicas: 1
@@ -389,8 +389,8 @@ portal:
 
 core:
   image:
-    repository: registry.suse.de/devel/caps/registry/2.0/containers/registry/harbor-core
-    tag: 2.0.2-rev1
+    repository: registry.suse.com/registry/harbor-core
+    tag: 2.0.2
   # set the service account to be used, default if left empty
   serviceAccountName: ""
   replicas: 1
@@ -422,8 +422,8 @@ core:
 
 jobservice:
   image:
-    repository: registry.suse.de/devel/caps/registry/2.0/containers/registry/harbor-jobservice
-    tag: 2.0.2-rev1
+    repository: registry.suse.com/registry/harbor-jobservice
+    tag: 2.0.2
   replicas: 1
   # set the service account to be used, default if left empty
   serviceAccountName: ""
@@ -449,8 +449,8 @@ registry:
   serviceAccountName: ""
   registry:
     image:
-      repository: registry.suse.de/devel/caps/registry/2.0/containers/registry/harbor-registry
-      tag: 2.0.2-rev1
+      repository: registry.suse.com/registry/harbor-registry
+      tag: 2.0.2
 
     # resources:
     #  requests:
@@ -458,8 +458,8 @@ registry:
     #    cpu: 100m
   controller:
     image:
-      repository: registry.suse.de/devel/caps/registry/2.0/containers/registry/harbor-registryctl
-      tag: 2.0.2-rev1
+      repository: registry.suse.com/registry/harbor-registryctl
+      tag: 2.0.2
 
     # resources:
     #  requests:
@@ -555,9 +555,9 @@ trivy:
   enabled: true
   image:
     # repository the repository for Trivy adapter image
-    repository: registry.suse.de/devel/caps/registry/2.0/containers/registry/harbor-trivy-adapter
+    repository: registry.suse.com/registry/harbor-trivy-adapter
     # tag the tag for Trivy adapter image
-    tag: 2.0.2-rev1
+    tag: 2.0.2
   # set the service account to be used, default if left empty
   serviceAccountName: ""
   # replicas the number of Pod replicas
@@ -649,8 +649,8 @@ database:
     # set the service account to be used, default if left empty
     serviceAccountName: ""
     image:
-      repository: registry.suse.de/devel/caps/registry/2.0/containers/registry/harbor-db
-      tag: 2.0.2-rev1
+      repository: registry.suse.com/registry/harbor-db
+      tag: 2.0.2
     # The initial superuser password for internal database
     password: "changeit"
     # resources:
@@ -695,8 +695,8 @@ redis:
     # set the service account to be used, default if left empty
     serviceAccountName: ""
     image:
-      repository: registry.suse.de/devel/caps/registry/2.0/containers/registry/harbor-redis
-      tag: 2.0.2-rev1
+      repository: registry.suse.com/registry/harbor-redis
+      tag: 2.0.2
     # resources:
     #  requests:
     #    memory: 256Mi
@@ -735,16 +735,16 @@ tests:
     exclude:
       - singularity # CLI not yet included in the harbor-test-image
     image:
-      repository: registry.suse.de/devel/caps/registry/2.0/containers/registry/harbor-test
-      tag: 2.0.2-rev1
+      repository: registry.suse.com/registry/harbor-test
+      tag: 2.0.2
     # resources:
     #  requests:
     #    memory: 128Mi
     #    cpu: 100m
     dind:
       image:
-        repository: registry.suse.de/devel/caps/registry/2.0/containers/registry/docker-dind
-        tag: 2.0.2-rev1
+        repository: registry.suse.com/registry/docker-dind
+        tag: 2.0.2
       # resources:
       #  requests:
       #    memory: 128Mi


### PR DESCRIPTION
(backport of #32 )

Insert tag macros into the Chart.yaml file, to be filled in at
build time by the build service.

Use registry.suse.com as the default registry for image references
in the helm chart and only reference version tags (i.e. without
any revision or build numbers).

Add a values-dev.yaml override that can be used as an additional
helm values file to point to development images coming from
registry.suse.de. This can also be replaced by a build source
service with a registry path corresponding to the build project
where the chart is actually built.