### PR TITLE
Set allowPrivilegeEscalation on test sidecar container

### DIFF
--- a/harbor-helm/templates/tests/api.yaml
+++ b/harbor-helm/templates/tests/api.yaml
@@ -82,6 +82,7 @@ spec:
         {{- end }}
       securityContext:
         privileged: true
+        allowPrivilegeEscalation: true
 {{- if .Values.tests.api.dind.resources }}
       resources:
 {{ toYaml .Values.tests.api.dind.resources | indent 8 }}


### PR DESCRIPTION
Required when running on kubernetes <= 1.16.

(cherry picked from commit dbc0bf7de9f97aaa2f302045e40eba47d3b3ea87)