### PR TITLE
Enable image scan tests when trivy is enabled

### DIFF
--- a/harbor-helm/templates/_helpers.tpl
+++ b/harbor-helm/templates/_helpers.tpl
@@ -614,8 +614,6 @@ host:port,pool_size,password
   {{- end -}}
   {{- if not .Values.trivy.enabled -}}
     {{- $el = append $el "push_index" -}}
-  {{- end -}}
-  {{- if or (not .Values.trivy.enabled) (not .Values.clair.enabled) -}}
     {{- $el = append $el "scan" -}}
     {{- $el = append $el "scan_all" -}}
   {{- end -}}


### PR DESCRIPTION
The image scan tests required two image scanners installed to
successfully run. With change [1] merged this is not required anymore so
the scan tests can be enabled whenever trivy is enabled.

1. https://build.suse.de/request/show/225608