### PR TITLE
Add missing registry/controller image to values-dev

### DIFF
--- a/harbor-helm/values-dev.yaml
+++ b/harbor-helm/values-dev.yaml
@@ -18,6 +18,9 @@ registry:
   registry:
     image:
       repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-registry
+  controller:
+    image:
+      repository: registry.suse.de/devel/caps/registry/containers/registry/harbor-registryctl
 
 trivy:
   image:


### PR DESCRIPTION
The entry for the registry controller image is missing on
values-dev.yaml file.

(cherry picked from commit d3813bd7aea28d8ddda715e5c3eece4cbdd8a3bf)