### PR TITLE
[2.0] Fix ingress TLS annotations

### DIFF
--- a/harbor-helm/templates/ingress/ingress.yaml
+++ b/harbor-helm/templates/ingress/ingress.yaml
@@ -35,6 +35,8 @@ metadata:
 {{ toYaml $ingress.annotations | indent 4 }}
 {{- if .Values.internalTLS.enabled }}
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    # Required for older nginx-ingress versions
+    nginx.ingress.kubernetes.io/secure-backends: 'true'
 {{- end }}
 
 spec:


### PR DESCRIPTION
The nginx-ingress version supplied with CaaSP 4.2 is old and does
not support the newer `backend-protocol` annotation [1]. For older
nginx ingress versions, the `secure-backends` annotation [2] needs
to be used, otherwise the internal TLS support for Harbor doesn't
work.

[1] https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#backend-protocol
[2] https://github.com/kubernetes/ingress-nginx/blob/nginx-0.15.0/docs/user-guide/nginx-configuration/annotations.md#secure-backends