### PR TITLE
Add workflows for periodic testing of SUSE Private Registry

### DIFF
--- a/.github/workflows/cluster-rotate.yml
+++ b/.github/workflows/cluster-rotate.yml
@@ -1,0 +1,126 @@
+name: "[CaaSP 4] Rotate Cluster"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
+
+jobs:
+  redeploy_caasp_cluster:
+    name: Redeploy and set active cluster
+    runs-on: ecosystem-ci-runners
+    env:
+      CLUSTER_PREFIX: registry-ci
+      NUMBER_OF_CLUSTERS: 2
+      GH_API_HEADER: "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"
+    steps:
+      - name: Find out which cluster to redeploy
+        id: get_cluster
+        run: |
+          artifact_name=cluster-id
+          previous_runs_artifacts_url=$(curl -sH "${GH_API_HEADER}" \
+            https://api.github.com/repos/${{ github.repository }}/actions/workflows/cluster-rotate.yml/runs\?status\=completed \
+             | jq -r ".workflow_runs[].artifacts_url")
+          for artifact_url in "${previous_runs_artifacts_url}"; do
+            cluster_id_artifact_download_url=$(curl -sH "${GH_API_HEADER}" ${artifact_url} \
+              | jq -rc ".artifacts[] | select(.name==\"${artifact_name}\") | .archive_download_url")
+            if [[ ! -z "${cluster_id_artifact_download_url}" ]]; then
+              break
+            fi
+          done
+          cluster_id=1
+          if [[ ! -z "${cluster_id_artifact_download_url}" ]]; then
+            curl -sLH "${GH_API_HEADER}" ${cluster_id_artifact_download_url} --output ${artifact_name}.zip
+            unzip -o ${artifact_name}.zip
+            active_cluster_id=$(cat CLUSTER_ID)
+            echo "::set-env name=ACTIVE_CLUSTER_ID::${active_cluster_id}"
+            if [[ -z "${active_cluster_id}" || ${active_cluster_id} = ${NUMBER_OF_CLUSTERS} ]]; then
+              cluster_id=1
+            else
+              cluster_id=$(($active_cluster_id + 1))
+            fi
+          fi
+          echo ${cluster_id} > CLUSTER_ID
+          echo "::set-env name=CLUSTER_NAME::${CLUSTER_PREFIX}${cluster_id}"
+          echo "::set-output name=previous_runs_artifacts_url::${previous_runs_artifacts_url//$'\n'/'%0A'}"
+          echo "::warning::Redeploying cluster ${CLUSTER_PREFIX}${cluster_id}"
+      - name: Drop OPENRC
+        env:
+          sec_openrc: ${{ secrets.OPENRC }}
+        run: echo "$sec_openrc" | base64 -d > ./.openrc
+      - name: '[CLEAN UP] Get catapult arficats from previuos run'
+        if: steps.get_cluster.outputs.previous_runs_artifacts_url
+        id: artifact_download
+        run: |
+          artifact_name=deployment-${CLUSTER_NAME}
+          for artifact_url in "${{ steps.get_cluster.outputs.previous_runs_artifacts_url }}" ; do
+            artifact_download_url=$(curl -sH "${GH_API_HEADER}" ${artifact_url} \
+              | jq -rc ".artifacts[] | select(.name==\"${artifact_name}\") | .archive_download_url")
+            if [[ ! -z "${artifact_download_url}" ]]; then
+              curl -sLH "${GH_API_HEADER}" $artifact_download_url --output ${artifact_name}.zip
+              rm -rf ${artifact_name}
+              mkdir ${artifact_name}
+              unzip ${artifact_name}.zip -d ${artifact_name}
+              echo "::set-output name=succeeded::true"
+              break
+            fi
+          done
+      - name: '[CLEAN UP] Delete non kubernetes system namespaces'
+        if: steps.artifact_download.outputs.succeeded
+        run: |
+          if [[ -f "deployment-${CLUSTER_NAME}/kubeconfig" ]]; then
+            export KUBECONFIG=deployment-${CLUSTER_NAME}/kubeconfig
+            for n in $(kubectl get ns -o=custom-columns=kube-:.metadata.name | grep -v "kube-\|default"); do
+              kubectl delete ns $n
+            done
+          fi
+      - name: '[CLEAN UP] Delete virtual resources on ECP'
+        if: steps.artifact_download.outputs.succeeded
+        run: |
+          . ./.openrc
+          cd deployment-${CLUSTER_NAME}/deployment
+          terraform init
+          terraform destroy -auto-approve
+      - name: Checkout catapult repository
+        uses: actions/checkout@v2
+        with:
+          repository: SUSE/catapult
+          path: catapult
+      - name: Deploy new CaaSP cluster
+        id: deploy_cluster
+        run: |
+          . ./.openrc
+          cd catapult
+          eval $(ssh-agent)
+          echo "::set-output name=step_reached::true"
+          OWNER=${CLUSTER_NAME} BACKEND=caasp4os make k8s
+          echo "::set-env name=KUBECONFIG::$(realpath build${{ env.CLUSTER_NAME }}/kubeconfig)"
+      - name: Archieve deployment artifacts
+        if: always() && steps.deploy_cluster.outputs.step_reached
+        uses: actions/upload-artifact@v2
+        with:
+          name: deployment-${{ env.CLUSTER_NAME }}
+          path: |
+            catapult/build${{ env.CLUSTER_NAME }}/deployment
+            catapult/build${{ env.CLUSTER_NAME }}/id_rsa_shared
+            catapult/build${{ env.CLUSTER_NAME }}/kubeconfig
+      - name: Deploy NGINX ingress controller
+        run: |
+          cat << EOF | tee nginx-ingress-config-values.yaml
+          controller:
+            service:
+              enableHttp: false
+              type: LoadBalancer
+            replicaCount: 1
+          EOF
+          helm repo add suse https://kubernetes-charts.suse.com
+          kubectl create ns nginx-ingress
+          helm -n nginx-ingress install nginx-ingress suse/nginx-ingress -f nginx-ingress-config-values.yaml --wait --timeout 5m
+      - name: Keep current cluster as active if this deployment fails
+        if: env.ACTIVE_CLUSTER_ID && (failure() || (cancelled() && steps.deploy_cluster.outputs.step_reached))
+        run: echo ${ACTIVE_CLUSTER_ID} > CLUSTER_ID
+      - name: Save active cluster ID
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: cluster-id
+          path: CLUSTER_ID

--- a/.github/workflows/periodic-20.yml
+++ b/.github/workflows/periodic-20.yml
@@ -1,0 +1,169 @@
+name: "SUSE Private Registry:2.0"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 */3 * * *"
+
+jobs:
+  test_suse_private_registry:
+    name: Integration Tests
+    runs-on: ecosystem-ci-runners
+    strategy:
+      fail-fast: false
+      matrix:
+        # devel   -> Devel:CAPS:Registry:2.0
+        # suse    -> SUSE:SLE-15-SP2:Update:Products:CAPS-Registry:2.0
+        # release -> SUSE:Containers:CAPS:2
+        source: [devel, suse, release, release-to-devel, release-to-suse]
+        include:
+          - source: devel
+            install_src: registry.suse.de/devel/caps/registry/2.0
+          - source: suse
+            install_src: registry.suse.de/suse/sle-15-sp2/update/products/caps-registry/2.0
+          - source: release
+            install_src: registry.suse.de/suse/containers/caps/2
+          - source: release-to-devel
+            install_src: registry.suse.de/suse/containers/caps/2
+            upgrade_src: registry.suse.de/devel/caps/registry/2.0
+          - source: release-to-suse
+            install_src: registry.suse.de/suse/containers/caps/2
+            upgrade_src: registry.suse.de/suse/sle-15-sp2/update/products/caps-registry/2.0
+    steps:
+      - name: Setup environment for job triggered by ${{ github.event_name }}
+        id: setup
+        run: |
+          case "${GITHUB_EVENT_NAME}" in
+            schedule|workflow_dispatch)
+              echo "::set-output name=env_ref::release-2.0"
+              echo "::set-output name=env_name::periodic-2.0"
+              echo "::set-env name=NAMESPACE::spr20-sched-${{ matrix.source }}"
+              ;;
+            *)
+              echo "::error::Trigger event ${GITHUB_EVENT_NAME} not supported by this workflow"
+              exit 1
+          esac
+      - name: Fetch kubeconfig from active CaaSP cluster
+        run: |
+          GH_API_HEADER="authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"
+          active_cluster_artifacts_url=$(curl -sH "${GH_API_HEADER}" \
+            https://api.github.com/repos/${{ github.repository }}/actions/workflows/cluster-rotate.yml/runs\?status\=success \
+            | jq -r ".workflow_runs[0].artifacts_url")
+          kubconfig_artifact_download_url=$(curl -sH "${GH_API_HEADER}" ${active_cluster_artifacts_url} \
+            | jq -rc ".artifacts[] | select(.name | contains(\"deployment-registry-ci\")) | .archive_download_url")
+          catapult_deployment_zip="catapult_deployment.zip"
+          curl -sLH "${GH_API_HEADER}" $kubconfig_artifact_download_url --output "${catapult_deployment_zip}"
+          unzip -jo ${catapult_deployment_zip} kubeconfig
+          echo "::set-env name=KUBECONFIG::$(realpath ./kubeconfig)"
+      - name: Delete previous deployment
+        run: |
+          kubectl delete ns ${NAMESPACE} || true
+          kubectl create ns ${NAMESPACE}
+      - name: Get ingress IP
+        run: |
+          echo "::set-env name=INGRESS_IP::$(kubectl get svc nginx-ingress-controller -n nginx-ingress -o json | jq -r ".status.loadBalancer.ingress[].ip")"
+      - name: Generate helm values file for CI
+        run: |
+          cat << EOF | tee ${NAMESPACE}.yaml
+          expose:
+            ingress:
+              hosts:
+                core: "${NAMESPACE}.${INGRESS_IP}.nip.io"
+          externalURL: "https://${NAMESPACE}.${INGRESS_IP}.nip.io"
+          updateStrategy:
+            type: Recreate
+          internalTLS:
+            enabled: false
+          imagePullPolicy: Always
+          EOF
+      - name: Create GitHub deployment
+        uses: tallyb/deployments@0.5.0
+        id: deployment
+        with:
+          step: start
+          token: ${{ github.token }}
+          env: ${{ steps.setup.outputs.env_name }} (${{ matrix.source }})
+          ref: ${{ steps.setup.outputs.env_ref }}
+      - name: SUSE Private Registry (install)
+        env:
+          HELM_EXPERIMENTAL_OCI: 1
+        run: |
+          helm chart pull ${{ matrix.install_src }}/charts/registry/harbor:latest
+          helm chart export ${{ matrix.install_src }}/charts/registry/harbor:latest
+          chart="./harbor"
+          # replace images repository according to source
+          sed -i 's,registry.suse.com,${{ matrix.install_src }}/containers,g' ${chart}/values.yaml
+          helm install ${NAMESPACE} ${chart} -n ${NAMESPACE} --values ${NAMESPACE}.yaml --timeout 8m --wait
+      - name: SUSE Private Registry (upgrade)
+        if: matrix.upgrade_src
+        env:
+          HELM_EXPERIMENTAL_OCI: 1
+        run: |
+          helm chart pull ${{ matrix.upgrade_src }}/charts/registry/harbor:latest
+          helm chart export ${{ matrix.upgrade_src }}/charts/registry/harbor:latest
+          chart="./harbor"
+          # replace images repository according to source
+          sed -i 's,registry.suse.com,${{ matrix.upgrade_src }}/containers,g' ${chart}/values.yaml
+          helm upgrade ${NAMESPACE} ${chart} -n ${NAMESPACE} --values ${NAMESPACE}.yaml --timeout 8m --wait
+      - name: Run tests
+        id: run_tests
+        run: |
+          set +e
+          release_name=${NAMESPACE}
+          namespace=${NAMESPACE}
+          helm test -n $namespace $release_name --timeout 30m &
+          helm_test_pid=$!
+          test_pods=$(helm status -n $namespace $release_name -o json | jq -r .hooks[].name)
+          until kubectl exec -n $namespace $test_pods "--" pgrep pybot &> /dev/null; do
+            sleep 1
+          done
+          while kubectl exec -n $namespace $test_pods "--" pgrep pybot &> /dev/null; do
+            sleep 1
+          done
+          kubectl cp -n $namespace $test_pods:/var/lib/harbor-test/output.xml output.xml
+          wait $helm_test_pid
+          status=$?
+          rm -rf test_reports/
+          rebot -d test_reports --log api_log.html --report api_report.html --xunit api_xunit.xml output.xml
+          echo "::set-output name=has_artifacts::true"
+          exit $status
+      - name: Collect logs from pods
+        if: always()
+        run: |
+          rm -rf pods_logs
+          mkdir pods_logs && cd pods_logs
+          for pod in $(kubectl get pods -n ${NAMESPACE} -o json | jq -r ".items[].metadata.name"); do
+            mkdir $pod && pushd $pod
+            kubectl -n ${NAMESPACE} get pod $pod -o json | jq ".status.containerStatuses[]" > status.info
+            for container in $(kubectl -n ${NAMESPACE} get pod $pod -o json | jq -r ".status.containerStatuses[].name"); do
+              kubectl -n ${NAMESPACE} logs $pod -c $container > $container.log
+            done
+            popd
+          done
+      - name: Archive logs from pods
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs-${{ matrix.source }}
+          path: pods_logs/*
+      - name: Archive test results
+        if: always() && steps.run_tests.outputs.has_artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: test_report-${{ matrix.source }}
+          path: test_reports/*
+      - name: Process test results
+        if: always() && steps.run_tests.outputs.has_artifacts
+        uses: flaviodsr/junit-report-annotations-action@master
+        with:
+          path: test_reports/api_xunit.xml
+      - name: Update GitHub deployment status
+        if: always()
+        uses: tallyb/deployments@0.5.0
+        with:
+          step: finish
+          token: ${{ github.token }}
+          status: ${{ job.status }}
+          env_url: https://${{ env.NAMESPACE }}.${{ env.INGRESS_IP }}.nip.io
+          logs: https://${{ env.NAMESPACE }}.${{ env.INGRESS_IP }}.nip.io
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+


### PR DESCRIPTION
This change introduces two workflows for testing SUSE Private Registry
periodically:
  * **[CaaSP 4] Rotate Cluster**: This workflow is triggered daily at 4
    am and it is responsible for deploying a new CaaSP cluster on ECP,
    it also deploys the NGINX ingress controller on the cluster.
    To ensure that we always have a cluster available it works by keeping
    the `NUMBER_OF_CLUSTERS` deployed and redeploying only the oldest one
    until it succeeds.
  * **SUSE Private Registry:2.0**: This workflow has one job
    (Integration Tests) which is executed every three hours. It is
    responsible for testing SUSE Private Registry from devel, suse and
    and release areas by deploying it at the last CaaSP cluster deployed
    by the `[CaaSP 4] Rotate Cluster` workflow and running the API tests.