### PR TITLE
Tests: Set NOTARY_URL when using notary with ingress

### DIFF
--- a/harbor-helm/templates/tests/api.yaml
+++ b/harbor-helm/templates/tests/api.yaml
@@ -28,6 +28,10 @@ spec:
       env:
         - name: HARBOR_IP
           value: {{ .Values.externalURL | replace "https://" "" }}
+        {{- if and .Values.notary.enabled (eq .Values.expose.type "ingress") }}
+        - name: NOTARY_URL
+          value: https://{{ .Values.expose.ingress.hosts.notary }}
+        {{- end }}
         - name: ROBOT_OPTIONS
           value: "{{ template "harbor.tests.api.options" . }}"
         - name: DOCKER_HOST


### PR DESCRIPTION
By default the tests expect notary to be served on the 4443 port,
however when using an ingress it is served on 443. This change sets the
`NOTARY_URL` environment variable on the api-tests container with the
value defined on expose.ingress.hosts.notary so the tests are executed
using the correct notary url.