### PR TITLE
Remove duplicate `registry.serviceAccountName` variable from values

### DIFF
--- a/harbor-helm/values.yaml
+++ b/harbor-helm/values.yaml
@@ -465,8 +465,6 @@ registry:
     #  requests:
     #    memory: 256Mi
     #    cpu: 100m
-  # set the service account to be used, default if left empty
-  serviceAccountName: ""
   replicas: 1
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
The same variable is already defined at line 449 at `values.yaml`