### PR TITLE
[2.0] Add notary to SUSE Private Registry

### DIFF
--- a/harbor-helm/values.yaml
+++ b/harbor-helm/values.yaml
@@ -614,8 +614,8 @@ notary:
     # set the service account to be used, default if left empty
     serviceAccountName: ""
     image:
-      repository: goharbor/notary-server-photon
-      tag: v2.0.2
+      repository: registry.suse.com/harbor/harbor-notary-server
+      tag: 2.0.2
     replicas: 1
     # resources:
     #  requests:
@@ -625,8 +625,8 @@ notary:
     # set the service account to be used, default if left empty
     serviceAccountName: ""
     image:
-      repository: goharbor/notary-signer-photon
-      tag: v2.0.2
+      repository: registry.suse.com/harbor/harbor-notary-signer
+      tag: 2.0.2
     replicas: 1
     # resources:
     #  requests:


### PR DESCRIPTION
(backport of #57)

Add notary to SUSE Private Registry, but keep it disabled by default.

