### PR TITLE
Update the 2.0 CI jobs to use the new helm chart tagging scheme

### DIFF
--- a/.github/workflows/periodic-20.yml
+++ b/.github/workflows/periodic-20.yml
@@ -18,16 +18,23 @@ jobs:
         include:
           - source: devel
             install_src: registry.suse.de/devel/caps/registry/2.0
+            install_src_suffix: harbor/harbor:1.4
           - source: suse
             install_src: registry.suse.de/suse/sle-15-sp2/update/products/caps-registry/2.0
+            install_src_suffix: registry/harbor:latest
           - source: release
             install_src: registry.suse.de/suse/containers/caps/2
+            install_src_suffix: registry/harbor:latest
           - source: release-to-devel
             install_src: registry.suse.de/suse/containers/caps/2
+            install_src_suffix: registry/harbor:latest
             upgrade_src: registry.suse.de/devel/caps/registry/2.0
+            upgrade_src_suffix: harbor/harbor:1.4
           - source: release-to-suse
             install_src: registry.suse.de/suse/containers/caps/2
+            install_src_suffix: registry/harbor:latest
             upgrade_src: registry.suse.de/suse/sle-15-sp2/update/products/caps-registry/2.0
+            upgrade_src_suffix: registry/harbor:latest
     steps:
       - name: Setup environment for job triggered by ${{ github.event_name }}
         id: setup
@@ -89,8 +96,8 @@ jobs:
         run: |
           chart="./harbor"
           rm -rf ${chart}
-          helm chart pull ${{ matrix.install_src }}/charts/registry/harbor:latest
-          helm chart export ${{ matrix.install_src }}/charts/registry/harbor:latest
+          helm chart pull ${{ matrix.install_src }}/charts/${{ matrix.install_src_suffix }}
+          helm chart export ${{ matrix.install_src }}/charts/${{ matrix.install_src_suffix }}
           # replace images repository according to source
           sed -i 's,registry.suse.com,${{ matrix.install_src }}/containers,g' ${chart}/values.yaml
           helm install ${NAMESPACE} ${chart} -n ${NAMESPACE} --values ${NAMESPACE}.yaml --timeout 8m --wait
@@ -101,8 +108,8 @@ jobs:
         run: |
           chart="./harbor"
           rm -rf ${chart}
-          helm chart pull ${{ matrix.upgrade_src }}/charts/registry/harbor:latest
-          helm chart export ${{ matrix.upgrade_src }}/charts/registry/harbor:latest
+          helm chart pull ${{ matrix.upgrade_src }}/charts/${{ matrix.upgrade_src_suffix }}
+          helm chart export ${{ matrix.upgrade_src }}/charts/${{ matrix.upgrade_src_suffix }}
           # replace images repository according to source
           sed -i 's,registry.suse.com,${{ matrix.upgrade_src }}/containers,g' ${chart}/values.yaml
           helm upgrade ${NAMESPACE} ${chart} -n ${NAMESPACE} --values ${NAMESPACE}.yaml --timeout 8m --wait

--- a/.github/workflows/periodic-20.yml
+++ b/.github/workflows/periodic-20.yml
@@ -100,7 +100,7 @@ jobs:
           helm chart export ${{ matrix.install_src }}/charts/${{ matrix.install_src_suffix }}
           # replace images repository according to source
           sed -i 's,registry.suse.com,${{ matrix.install_src }}/containers,g' ${chart}/values.yaml
-          helm install ${NAMESPACE} ${chart} -n ${NAMESPACE} --values ${NAMESPACE}.yaml --timeout 8m --wait
+          helm install ${NAMESPACE} ${chart} -n ${NAMESPACE} --values ${NAMESPACE}.yaml --timeout 8m --wait --set suse.AcceptBetaEULA=yes
       - name: SUSE Private Registry (upgrade)
         if: matrix.upgrade_src
         env:
@@ -112,7 +112,7 @@ jobs:
           helm chart export ${{ matrix.upgrade_src }}/charts/${{ matrix.upgrade_src_suffix }}
           # replace images repository according to source
           sed -i 's,registry.suse.com,${{ matrix.upgrade_src }}/containers,g' ${chart}/values.yaml
-          helm upgrade ${NAMESPACE} ${chart} -n ${NAMESPACE} --values ${NAMESPACE}.yaml --timeout 8m --wait
+          helm upgrade ${NAMESPACE} ${chart} -n ${NAMESPACE} --values ${NAMESPACE}.yaml --timeout 8m --wait --set suse.AcceptBetaEULA=yes
       - name: Run tests
         id: run_tests
         run: |


### PR DESCRIPTION
The helm chart was updated in 2.0.3 to use `harbor/harbor` as the
registry path instead of `registry/harbor` and to use the `1.4` tag
instead of `latest`, which is a cross-release moving target.