### PR TITLE
Fix the GC test failures and use the proper 1.5 tag in the 2.1 CI

### DIFF
--- a/.github/workflows/periodic-21.yml
+++ b/.github/workflows/periodic-21.yml
@@ -69,6 +69,9 @@ jobs:
               hosts:
                 core: "${NAMESPACE}.${INGRESS_IP}.nip.io"
           externalURL: "https://${NAMESPACE}.${INGRESS_IP}.nip.io"
+          core:
+            # Set the GC time window to 0 for the GC tests to pass
+            gcTimeWindowHours: 0
           trivy:
             gitHubToken: "${{ secrets.GITHUB_TOKEN }}"
           updateStrategy:

--- a/.github/workflows/periodic-21.yml
+++ b/.github/workflows/periodic-21.yml
@@ -94,8 +94,8 @@ jobs:
         run: |
           chart="./harbor"
           rm -rf ${chart}
-          helm chart pull ${{ matrix.install_src }}/charts/registry/harbor:latest
-          helm chart export ${{ matrix.install_src }}/charts/registry/harbor:latest
+          helm chart pull ${{ matrix.install_src }}/charts/registry/harbor:1.5
+          helm chart export ${{ matrix.install_src }}/charts/registry/harbor:1.5
           # replace images repository according to source
           sed -i 's,registry.suse.com,${{ matrix.install_src }}/containers,g' ${chart}/values.yaml
           helm install ${NAMESPACE} ${chart} -n ${NAMESPACE} --values ${NAMESPACE}.yaml --timeout 8m --wait
@@ -106,8 +106,8 @@ jobs:
         run: |
           chart="./harbor"
           rm -rf ${chart}
-          helm chart pull ${{ matrix.upgrade_src }}/charts/registry/harbor:latest
-          helm chart export ${{ matrix.upgrade_src }}/charts/registry/harbor:latest
+          helm chart pull ${{ matrix.upgrade_src }}/charts/registry/harbor:1.5
+          helm chart export ${{ matrix.upgrade_src }}/charts/registry/harbor:1.5
           # replace images repository according to source
           sed -i 's,registry.suse.com,${{ matrix.upgrade_src }}/containers,g' ${chart}/values.yaml
           helm upgrade ${NAMESPACE} ${chart} -n ${NAMESPACE} --values ${NAMESPACE}.yaml --timeout 8m --wait


### PR DESCRIPTION
* Use 1.5 instead of latest as a helm chart tag in the 2.1 CI

* Fix the garbage collection test failures: The integration tests expect the GC window to be set to 0, so that GC jobs have an immediate effect.
