### PR TITLE
Tests: pull images from library project

### DIFF
--- a/tests/registry/ha+redis-operator/values.yaml
+++ b/tests/registry/ha+redis-operator/values.yaml
@@ -61,7 +61,7 @@ tests:
   dockerCredentials:
     username: suseecosystem
     password: "${dh_access_token}"
-  imagesPullRepository: private-registry.prv.suse.net/dockerhub
+  imagesPullRepository: private-registry.prv.suse.net
   api:
     exclude:
       - singularity # CLI not yet included in the harbor-test-image

--- a/tests/registry/no-ha/values.yaml
+++ b/tests/registry/no-ha/values.yaml
@@ -31,4 +31,4 @@ tests:
   dockerCredentials:
     username: suseecosystem
     password: "${dh_access_token}"
-  imagesPullRepository: private-registry.prv.suse.net/dockerhub
+  imagesPullRepository: private-registry.prv.suse.net


### PR DESCRIPTION
The dockerhub project is configured as proxy-cache and its likely the cause of some tests failing with `500 Server Error: Internal Server Error`.

In that way, instead of pulling images from the dockerhub project on `private-registry.prv.suse.net`, pull it from the library project.